### PR TITLE
Improve target handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,9 +226,11 @@ Note that if `CARGO_TARGET_DIR` (see https://doc.rust-lang.org/cargo/reference/e
 is specified in the environment, it takes precedence over `targetDirectory`, as cargo will output
 all build artifacts to it, regardless of what is being built, or where it was invoked.
 
+You may also override `CARGO_TARGET_DIR` variable by setting `rust.cargoTargetDir` in `local.properties`, however it seems very unlikely that this will be useful, as we don't pass this information to cargo itself. That said, it can be used to control where we search for the built library on a per-machine basis.
+
 ```groovy
 cargo {
-    // Note: path is relative to the gradle project root.
+    // Note: path is relative to the gradle project's `projectDir`
     targetDirectory = 'path/to/workspace/root/target'
 }
 ```
@@ -302,9 +304,9 @@ rust.targets.library=linux-x86-64
 rust.targets=arm,linux-x86-64,darwin
 ```
 
-## Specifying paths to sub-commands (Python and Cargo)
+## Specifying paths to sub-commands (Python, Cargo, and Rustc)
 
-The plugin invokes Python and Cargo.  In order of preference, the plugin determines what command to invoke for Python by:
+The plugin invokes Python, Cargo and Rustc.  In order of preference, the plugin determines what command to invoke for Python by:
 
 1. `rust.pythonCommand` in `${rootDir}/local.properties`
 1. the environment variable `RUST_ANDROID_GRADLE_PYTHON_COMMAND`
@@ -315,6 +317,14 @@ In order of preference, the plugin determines what command to invoke for Cargo b
 1. `rust.cargoCommand` in `${rootDir}/local.properties`
 1. the environment variable `RUST_ANDROID_GRADLE_CARGO_COMMAND`
 1. the default, `cargo`
+
+In order of preference, the plugin determines what command to invoke for `rustc` by:
+
+1. `rust.rustcCommand` in `${rootDir}/local.properties`
+1. the environment variable `RUST_ANDROID_GRADLE_RUSTC_COMMAND`
+1. the default, `rustc`
+
+(Note that failure to locate `rustc` is not fatal, however it may result in rebuilding the code more often than is necessary).
 
 Paths must be host operating system specific.  For example, on Windows:
 

--- a/README.md
+++ b/README.md
@@ -215,14 +215,21 @@ cargo {
 
 ### targetDirectory
 
-The target directory into which Cargo writes built outputs.
+The target directory into which Cargo writes built outputs. You will likely need to specify this
+if you are using a [cargo virtual workspace](https://doc.rust-lang.org/book/ch14-03-cargo-workspaces.html),
+as our default will likely fail to locate the correct target directory.
 
 Defaults to `${module}/target`.  `targetDirectory` is interpreted as a relative path to the Gradle
 `projectDir`.
 
+Note that if `CARGO_TARGET_DIR` (see https://doc.rust-lang.org/cargo/reference/environment-variables.html)
+is specified in the environment, it takes precedence over `targetDirectory`, as cargo will output
+all build artifacts to it, regardless of what is being built, or where it was invoked.
+
 ```groovy
 cargo {
-    targetDirectory = 'release'
+    // Note: path is relative to the gradle project root.
+    targetDirectory = 'path/to/workspace/root/target'
 }
 ```
 

--- a/plugin/src/main/kotlin/com/nishtahir/CargoBuildTask.kt
+++ b/plugin/src/main/kotlin/com/nishtahir/CargoBuildTask.kt
@@ -6,10 +6,12 @@ import org.gradle.api.GradleException
 import org.gradle.api.Project
 import org.gradle.api.logging.LogLevel
 import org.gradle.api.tasks.TaskAction
+import java.io.ByteArrayOutputStream
 import java.io.File
 
 open class CargoBuildTask : DefaultTask() {
     var toolchain: Toolchain? = null
+
 
     @Suppress("unused")
     @TaskAction
@@ -30,12 +32,24 @@ open class CargoBuildTask : DefaultTask() {
             // CARGO_TARGET_DIR can be used to force the use of a global, shared target directory
             // across all rust projects on a machine. Use it if it's set, otherwise use the
             // configured `targetDirectory` value, and fall back to `${module}/target`.
-            val targetDirectory = System.getenv("CARGO_TARGET_DIR")
+            //
+            // We also allow this to be specified in `local.properties`, not because this is
+            // something you should ever need to do currently, but we don't want it to ruin anyone's
+            // day if it turns out we're wrong about that.
+            val targetDirectory =
+                getProperty("rust.cargoTargetDir", "CARGO_TARGET_DIR")
                 ?: targetDirectory
                 ?: "${module!!}/target"
 
+            val defaultTargetTriple = getDefaultTargetTriple(project, rustcCommand)
+
+            val cargoOutputDir = if (toolchain.target == defaultTargetTriple) {
+                "${targetDirectory}/${profile}"
+            } else {
+                "${targetDirectory}/${toolchain.target}/${profile}"
+            }
             copy { spec ->
-                spec.from(File(project.projectDir, "${targetDirectory}/${toolchain.target}/${profile}"))
+                spec.from(File(project.projectDir, cargoOutputDir))
                 spec.into(File(buildDir, "rustJniLibs/${toolchain.folder}"))
 
                 // Need to capture the value to dereference smoothly.
@@ -56,6 +70,7 @@ open class CargoBuildTask : DefaultTask() {
     inline fun <reified T : BaseExtension> buildProjectForTarget(project: Project, toolchain: Toolchain, cargoExtension: CargoExtension) {
         val app = project.extensions[T::class]
         val apiLevel = cargoExtension.apiLevel ?: app.defaultConfig.minSdkVersion.apiLevel
+        val defaultTargetTriple = getDefaultTargetTriple(project, cargoExtension.rustcCommand)
 
         project.exec { spec ->
             if (cargoExtension.exec != null) {
@@ -105,8 +120,12 @@ open class CargoBuildTask : DefaultTask() {
                     // two values.
                     theCommandLine.add("--${cargoExtension.profile}")
                 }
-
-                theCommandLine.add("--target=${toolchain.target}")
+                if (toolchain.target != defaultTargetTriple) {
+                    // Only providing --target for the non-default targets means desktop builds
+                    // can share the build cache with `cargo build`/`cargo test`/etc invocations,
+                    // instead of requiring a large amount of redundant work.
+                    theCommandLine.add("--target=${toolchain.target}")
+                }
 
                 // Target-specific environment configuration, passed through to
                 // the underlying `cargo build` invocation.
@@ -166,3 +185,34 @@ open class CargoBuildTask : DefaultTask() {
         }.assertNormalExitValue()
     }
 }
+
+// This can't be private/internal as it's called from `buildProjectForTarget`.
+fun getDefaultTargetTriple(project: Project, rustc: String): String? {
+    val stdout = ByteArrayOutputStream()
+    val result = project.exec { spec ->
+        spec.standardOutput = stdout
+        spec.commandLine = listOf(rustc, "--version", "--verbose")
+    }
+    if (result.exitValue != 0) {
+        project.logger.warn(
+            "Failed to get default target triple from rustc (exit code: ${result.exitValue})")
+        return null
+    }
+    val output = stdout.toString()
+
+    // The `rustc --version --verbose` output contains a number of lines like `key: value`.
+    // We're only interested in `host: `, which corresponds to the default target triple.
+    val triplePrefix = "host: "
+
+    val triple = output.split("\n")
+        .find { it.startsWith(triplePrefix) }
+        ?.let { it.substring(triplePrefix.length).trim() }
+
+    if (triple == null) {
+        project.logger.warn("Failed to parse `rustc -Vv` output! (Please report a rust-android-gradle bug)")
+    } else {
+        project.logger.info("Default rust target triple: $triple")
+    }
+    return triple
+}
+

--- a/plugin/src/main/kotlin/com/nishtahir/CargoBuildTask.kt
+++ b/plugin/src/main/kotlin/com/nishtahir/CargoBuildTask.kt
@@ -27,8 +27,12 @@ open class CargoBuildTask : DefaultTask() {
                     is LibraryPlugin -> buildProjectForTarget<LibraryExtension>(project, toolchain, this)
                 }
             }
-
-            val targetDirectory = targetDirectory ?: "${module!!}/target"
+            // CARGO_TARGET_DIR can be used to force the use of a global, shared target directory
+            // across all rust projects on a machine. Use it if it's set, otherwise use the
+            // configured `targetDirectory` value, and fall back to `${module}/target`.
+            val targetDirectory = System.getenv("CARGO_TARGET_DIR")
+                ?: targetDirectory
+                ?: "${module!!}/target"
 
             copy { spec ->
                 spec.from(File(project.projectDir, "${targetDirectory}/${toolchain.target}/${profile}"))

--- a/plugin/src/main/kotlin/com/nishtahir/CargoExtension.kt
+++ b/plugin/src/main/kotlin/com/nishtahir/CargoExtension.kt
@@ -81,6 +81,14 @@ open class CargoExtension {
             return getProperty("rust.pythonCommand", "RUST_ANDROID_GRADLE_PYTHON_COMMAND") ?: "python"
         }
 
+    // Required so that we can parse the default triple out of `rustc --version --verbose`. Sadly,
+    // there seems to be no way to get this information out of cargo directly. Failure to locate
+    // this isn't fatal, however.
+    val rustcCommand: String
+        get() {
+            return getProperty("rust.rustcCommand", "RUST_ANDROID_GRADLE_RUSTC_COMMAND") ?: "rustc"
+        }
+
     internal fun getProperty(camelCaseName: String, snakeCaseName: String): String? {
         val local: String? = localProperties.getProperty(camelCaseName)
         if (local != null) {


### PR DESCRIPTION
This fixes #9 and #10.

The complexity is mainly in the fix for #10, to avoiding invoking `rustc --version --verbose` once per task. It completes somewhat quickly, but we often have a lot of tasks. Ideally we'd just use a Lazy<T>, static ctor, or some other way of doing the same thing we do automatically, but our need to pass in the Project prevents this.

I also improved the documentation for `targetDirectory` in the fix for #10, since it didn't explain when you might want to use it, and i think the example could be confusing (since there's a `release` folder inside the target directory).