### PR TITLE
Invoke the `exec` callback as late as possible

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,6 +262,29 @@ cargo {
 }
 ```
 
+### exec
+
+This is a callback taking the `ExecSpec` we're going to use to invoke cargo, and
+the relevant toolchain. It's called for each invocation of cargo. This generally
+is useful for the following scenarios:
+
+1. Specifying target-specific environment variables.
+1. Adding target-specific flags to the command line.
+1. Removing/modifying environment variables or command line options we would
+   provide by default.
+
+```groovy
+cargo {
+    exec { spec, toolchain ->
+        if (toolchain.target != "x86_64-apple-darwin") {
+            // Don't statically link on macOS desktop builds, for some
+            // entirely hypothetical reason.
+            spec.environment("EXAMPLELIB_STATIC", "1")
+        }
+    }
+}
+```
+
 ## Specifying NDK toolchains
 
 The plugin looks for (and will generate) per-target architecture standalone NDK toolchains as

--- a/README.md
+++ b/README.md
@@ -264,13 +264,13 @@ cargo {
 
 ### exec
 
-This is a callback taking the `ExecSpec` we're going to use to invoke cargo, and
-the relevant toolchain. It's called for each invocation of cargo. This generally
+This is a callback taking the `ExecSpec` we're going to use to invoke `cargo build`, and
+the relevant toolchain. It's called for each invocation of `cargo build`. This generally
 is useful for the following scenarios:
 
 1. Specifying target-specific environment variables.
 1. Adding target-specific flags to the command line.
-1. Removing/modifying environment variables or command line options we would
+1. Removing/modifying environment variables or command line options the rust-android-gradle plugin would
    provide by default.
 
 ```groovy

--- a/plugin/src/main/kotlin/com/nishtahir/CargoBuildTask.kt
+++ b/plugin/src/main/kotlin/com/nishtahir/CargoBuildTask.kt
@@ -54,10 +54,6 @@ open class CargoBuildTask : DefaultTask() {
         val apiLevel = cargoExtension.apiLevel ?: app.defaultConfig.minSdkVersion.apiLevel
 
         project.exec { spec ->
-            if (cargoExtension.exec != null) {
-                (cargoExtension.exec!!)(spec, toolchain)
-            }
-
             with(spec) {
                 standardOutput = System.out
                 workingDir = File(project.project.projectDir, cargoExtension.module!!)
@@ -158,6 +154,9 @@ open class CargoBuildTask : DefaultTask() {
                 }
 
                 commandLine = theCommandLine
+            }
+            if (cargoExtension.exec != null) {
+                (cargoExtension.exec!!)(spec, toolchain)
             }
         }.assertNormalExitValue()
     }


### PR DESCRIPTION
Specifically, after the commandline has been set, so that it can be modified in a target-specific manner if necessary (e.g. to work around https://github.com/rust-lang/cargo/issues/2524).

The `exec` property was also undocumented so I fixed that too.

AFAICT this doesn't break anything, but maybe there's a reason it needs to be early (in which case a more involved workaround for cargo#2524 would be needed 😢 )