### PR TITLE
Automatically configure CLANG_PATH so that build.rs code using clang-sys work correctly

### DIFF
--- a/plugin/src/main/kotlin/com/nishtahir/CargoBuildTask.kt
+++ b/plugin/src/main/kotlin/com/nishtahir/CargoBuildTask.kt
@@ -158,7 +158,6 @@ open class CargoBuildTask : DefaultTask() {
                     } else {
                         cargoExtension.toolchainDirectory
                     }
-
                     // Be aware that RUSTFLAGS can have problems with embedded
                     // spaces, but that shouldn't be a problem here.
                     val cc = File(toolchainDirectory, "${toolchain.cc(apiLevel)}").path;
@@ -182,6 +181,20 @@ open class CargoBuildTask : DefaultTask() {
                     // https://github.com/alexcrichton/cc-rs#external-configuration-via-environment-variables.
                     environment("CC_${toolchain.target}", cc)
                     environment("AR_${toolchain.target}", ar)
+
+                    // Set CLANG_PATH in the environment, so that bindgen (or anything
+                    // else using clang-sys in a build.rs) works properly, and doesn't
+                    // use host headers and such.
+                    val shouldConfigure = cargoExtension.getFlagProperty(
+                        "rust.autoConfigureClangSys",
+                        "RUST_ANDROID_GRADLE_AUTO_CONFIGURE_CLANG_SYS",
+                        // By default, only do this for non-desktop platforms. If we're
+                        // building for desktop, things should work out of the box.
+                        toolchain.type != ToolchainType.DESKTOP
+                    )
+                    if (shouldConfigure) {
+                        environment("CLANG_PATH", cc)
+                    }
 
                     // Configure our linker wrapper.
                     environment("RUST_ANDROID_GRADLE_PYTHON_COMMAND", cargoExtension.pythonCommand)

--- a/plugin/src/main/kotlin/com/nishtahir/CargoExtension.kt
+++ b/plugin/src/main/kotlin/com/nishtahir/CargoExtension.kt
@@ -1,6 +1,7 @@
 package com.nishtahir
 
 import org.gradle.api.Action
+import org.gradle.api.GradleException
 import org.gradle.api.Project
 import org.gradle.process.ExecSpec
 import java.io.File
@@ -89,6 +90,20 @@ open class CargoExtension {
         get() {
             return getProperty("rust.rustcCommand", "RUST_ANDROID_GRADLE_RUSTC_COMMAND") ?: "rustc"
         }
+
+    fun getFlagProperty(camelCaseName: String, snakeCaseName: String, ifUnset: Boolean): Boolean {
+        val propVal = getProperty(camelCaseName, snakeCaseName)
+        if (propVal == "1" || propVal == "true") {
+            return true
+        }
+        if (propVal == "0" || propVal == "false") {
+            return false
+        }
+        if (propVal == null || propVal == "") {
+            return ifUnset
+        }
+        throw GradleException("Illegal value for property \"$camelCaseName\" / \"$snakeCaseName\". Must be 0/1/true/false if set")
+    }
 
     internal fun getProperty(camelCaseName: String, snakeCaseName: String): String? {
         val local: String? = localProperties.getProperty(camelCaseName)


### PR DESCRIPTION
This lets e.g. bindgen locate the correct instance of clang. Without it, header paths have to be specified manually, and it's a real hassle.

It also adds a property that can be configured either in the environment (`RUST_ANDROID_GRADLE_AUTO_CONFIGURE_CLANG_SYS`) or in local.properties (`rust.autoConfigureClangSys`) to enable/disable setting CLANG_PATH. If you leave it blank, we'll set on non-desktop builds.

Still needs a little more testing. I think the clang binaries we're using on windows aren't actually clang, so I'm not sure if this will actually work there.

Fixes the same thing as https://github.com/mozilla/application-services/pull/1980