### PR TITLE
Added missing env var CXX_<triple>

### DIFF
--- a/plugin/src/main/kotlin/com/nishtahir/CargoBuildTask.kt
+++ b/plugin/src/main/kotlin/com/nishtahir/CargoBuildTask.kt
@@ -162,6 +162,7 @@ open class CargoBuildTask : DefaultTask() {
                     // Be aware that RUSTFLAGS can have problems with embedded
                     // spaces, but that shouldn't be a problem here.
                     val cc = File(toolchainDirectory, "${toolchain.cc(apiLevel)}").path;
+                    val cxx = File(toolchainDirectory, "${toolchain.cxx(apiLevel)}").path;
                     val ar = File(toolchainDirectory, "${toolchain.ar(apiLevel)}").path;
 
                     // For cargo: like "CARGO_TARGET_I686_LINUX_ANDROID_CC".  This is really weakly
@@ -181,6 +182,7 @@ open class CargoBuildTask : DefaultTask() {
                     // For build.rs in `cc` consumers: like "CC_i686-linux-android".  See
                     // https://github.com/alexcrichton/cc-rs#external-configuration-via-environment-variables.
                     environment("CC_${toolchain.target}", cc)
+                    environment("CXX_${toolchain.target}", cxx)
                     environment("AR_${toolchain.target}", ar)
 
                     // Configure our linker wrapper.
@@ -233,4 +235,3 @@ fun getDefaultTargetTriple(project: Project, rustc: String): String? {
     }
     return triple
 }
-

--- a/plugin/src/main/kotlin/com/nishtahir/RustAndroidPlugin.kt
+++ b/plugin/src/main/kotlin/com/nishtahir/RustAndroidPlugin.kt
@@ -113,6 +113,21 @@ data class Toolchain(val platform: String,
                 }
             }
 
+    fun cxx(apiLevel: Int): File =
+            if (System.getProperty("os.name").startsWith("Windows")) {
+                if (type == ToolchainType.ANDROID_PREBUILT) {
+                    File("bin", "$compilerTriple$apiLevel-clang++.cmd")
+                } else {
+                    File("$platform-$apiLevel/bin", "$compilerTriple-clang++.cmd")
+                }
+            } else {
+                if (type == ToolchainType.ANDROID_PREBUILT) {
+                    File("bin", "$compilerTriple$apiLevel-clang++")
+                } else {
+                    File("$platform-$apiLevel/bin", "$compilerTriple-clang++")
+                }
+            }
+
     fun ar(apiLevel: Int): File =
             if (type == ToolchainType.ANDROID_PREBUILT) {
                 File("bin", "$binutilsTriple-ar")


### PR DESCRIPTION
This is important also specify appropriate C++ compiler
for building bundled C++ libraries and/or bindings.

For example cmake fails compile rust bindings for liboboe
without it.