### PR TITLE
Fix documentation for noDefaultBut() / --no-default-features

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,9 +231,9 @@ To pass `--no-default-features`, and an optional list of replacement `--features
 ```groovy
 cargo {
     features {
-        noDefaultFeatures()
-        noDefaultFeatures("x")
-        noDefaultFeatures "x", "y"
+        noDefaultBut()
+        noDefaultBut("x")
+        noDefaultBut "x", "y"
     }
 }
 ```


### PR DESCRIPTION
`README.md` did not match the code, which requires `noDefaultBut` rather than `noDefaultFeatures`.