### PR TITLE
Add `apiLevels` parameter, controlling API level per target

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,6 +288,20 @@ cargo {
 }
 ```
 
+You may specify the API level per target in `targets` using the `apiLevels` option. At most one of
+`apiLevel` and `apiLevels` may be specified. `apiLevels` must have an entry for each target in
+`targets`.
+
+```groovy
+cargo {
+    targets = ["arm", "x86_64"]
+    apiLevels = [
+        "arm": 16,
+        "x86_64": 21,
+    ]
+}
+```
+
 ### extraCargoBuildArguments
 
 Sometimes, you need to do things that the plugin doesn't anticipate.  Use `extraCargoBuildArguments`

--- a/plugin/src/main/kotlin/com/nishtahir/CargoExtension.kt
+++ b/plugin/src/main/kotlin/com/nishtahir/CargoExtension.kt
@@ -42,6 +42,7 @@ open class CargoExtension {
     var targetDirectory: String? = null
     var targetIncludes: Array<String>? = null
     var apiLevel: Int? = null
+    var apiLevels: Map<String, Int> = mapOf()
     var extraCargoBuildArguments: List<String>? = null
 
     // It would be nice to use a receiver here, but there are problems interoperating with Groovy

--- a/plugin/src/main/kotlin/com/nishtahir/GenerateToolchainsTask.kt
+++ b/plugin/src/main/kotlin/com/nishtahir/GenerateToolchainsTask.kt
@@ -24,7 +24,6 @@ open class GenerateToolchainsTask : DefaultTask() {
     inline fun <reified T : BaseExtension> configureTask(project: Project) {
         val cargoExtension = project.extensions[CargoExtension::class]
         val app = project.extensions[T::class]
-        val apiLevel = cargoExtension.apiLevel ?: app.defaultConfig.minSdkVersion.apiLevel
         val ndkPath = app.ndkDirectory
 
         // It's safe to unwrap, since we bailed at configuration time if this is unset.
@@ -34,6 +33,9 @@ open class GenerateToolchainsTask : DefaultTask() {
                 .filter { it.type == ToolchainType.ANDROID_GENERATED }
                 .filter { (arch) -> targets.contains(arch) }
                 .forEach { (arch) ->
+                     // We ensure all architectures have an API level at configuration time
+                     val apiLevel = cargoExtension.apiLevels[arch]!!
+
                      if (arch.endsWith("64") && apiLevel < 21) {
                         throw GradleException("Can't target 64-bit ${arch} with API level < 21 (${apiLevel})")
                     }


### PR DESCRIPTION
For compatibility with the maximum number of Android devices, it may be desirable to specify a lower API level for certain targets. While 64-bit JNI requires a minimum API level of 21, 32-bit JNI can be used with older API levels. My team's project uses this method to get the benefits of 64-bit performance on newer devices while also supporting older 32-bit phones.