### PR TITLE
Remove deprecated Cargo environment variables

### DIFF
--- a/plugin/src/main/kotlin/com/nishtahir/CargoBuildTask.kt
+++ b/plugin/src/main/kotlin/com/nishtahir/CargoBuildTask.kt
@@ -167,17 +167,6 @@ open class CargoBuildTask : DefaultTask() {
                     } else {
                         cargoExtension.toolchainDirectory
                     }
-                    // Be aware that RUSTFLAGS can have problems with embedded
-                    // spaces, but that shouldn't be a problem here.
-                    val cc = File(toolchainDirectory, "${toolchain.cc(apiLevel)}").path;
-                    val cxx = File(toolchainDirectory, "${toolchain.cxx(apiLevel)}").path;
-                    val ar = File(toolchainDirectory, "${toolchain.ar(apiLevel)}").path;
-
-                    // For cargo: like "CARGO_TARGET_I686_LINUX_ANDROID_CC".  This is really weakly
-                    // documented; see https://github.com/rust-lang/cargo/issues/5690 and follow
-                    // links from there.
-                    environment("CARGO_TARGET_${toolchain_target}_CC", cc)
-                    environment("CARGO_TARGET_${toolchain_target}_AR", ar)
 
                     val linker_wrapper =
                     if (System.getProperty("os.name").startsWith("Windows")) {
@@ -186,6 +175,10 @@ open class CargoBuildTask : DefaultTask() {
                         File(project.rootProject.buildDir, "linker-wrapper/linker-wrapper.sh")
                     }
                     environment("CARGO_TARGET_${toolchain_target}_LINKER", linker_wrapper.path)
+
+                    val cc = File(toolchainDirectory, "${toolchain.cc(apiLevel)}").path;
+                    val cxx = File(toolchainDirectory, "${toolchain.cxx(apiLevel)}").path;
+                    val ar = File(toolchainDirectory, "${toolchain.ar(apiLevel)}").path;
 
                     // For build.rs in `cc` consumers: like "CC_i686-linux-android".  See
                     // https://github.com/alexcrichton/cc-rs#external-configuration-via-environment-variables.


### PR DESCRIPTION
Setting AR and CC via Cargo is not supported. AR is still documented but marked deprecated here:
https://doc.rust-lang.org/nightly/cargo/reference/config.html#targettriplear
https://doc.rust-lang.org/rustc/codegen-options/index.html#ar

Setting CC via config is not documented at all now, and searching for cc
in Cargo source code also comes up empty. It's also missing from the
`rustc` codegen options link above.

I also removed a comment reference to RUSTFLAGS which doesn't appear to be
accurate (we don't set or modify RUSTFLAGS anywhere in this library)