### PR TITLE
Use per-platform API level for selecting toolchain

### DIFF
--- a/plugin/src/main/kotlin/com/nishtahir/CargoBuildTask.kt
+++ b/plugin/src/main/kotlin/com/nishtahir/CargoBuildTask.kt
@@ -70,7 +70,7 @@ open class CargoBuildTask : DefaultTask() {
 
     inline fun <reified T : BaseExtension> buildProjectForTarget(project: Project, toolchain: Toolchain, cargoExtension: CargoExtension) {
         val app = project.extensions[T::class]
-        val apiLevel = cargoExtension.apiLevel ?: app.defaultConfig.minSdkVersion.apiLevel
+        val apiLevel = cargoExtension.apiLevels[toolchain.platform]!!
         val defaultTargetTriple = getDefaultTargetTriple(project, cargoExtension.rustcCommand)
 
         project.exec { spec ->


### PR DESCRIPTION
Now that `apiLevels` can be relied on to have the correct per-platform API level, this heuristic can be replaced
with a direct lookup. I tested this by building the sample app:

```
./gradlew -p samples/app assembleRelease
./gradlew -p samples/app assembleDebug
```