### PR TITLE
Correct linker-wrapper script under Msys2 and Cygwin. Fixes #58

### DIFF
--- a/plugin/src/main/resources/com/nishtahir/linker-wrapper.bat
+++ b/plugin/src/main/resources/com/nishtahir/linker-wrapper.bat
@@ -1,1 +1,18 @@
+@echo off
+if defined SHELL (
+    where /q cygpath
+    if ERRORLEVEL 1 (
+        goto WINSHELL
+    )
+    for /f %%i in ('cygpath -w %SHELL%') do (
+        if exist "%%i" (
+            "%%i" -c 'RUST_ANDROID_GRADLE_CC="$(cygpath -u "${RUST_ANDROID_GRADLE_CC%%.*}")";^
+                      exec "$(cygpath -u "%~dp0linker-wrapper.sh")" "%*"'
+            exit !errorlevel!
+        )
+        exit 1
+    )
+)
+:WINSHELL
+@echo on
 "%RUST_ANDROID_GRADLE_PYTHON_COMMAND%" "%RUST_ANDROID_GRADLE_LINKER_WRAPPER_PY%" %*


### PR DESCRIPTION
Because rustc can not run shell script under windows bash, so make a hack in `linker-wrapper.bat`, if `SEHLL` variable is defind and find `cygpath` then try run shell script. Otherwise the default behavior will be used
Another fix is convert `RUST_ANDROID_GRADLE_CC` to unix path when run with native python under Msys2 and Cygwin. if run with native python under Msys2 and Cygwin the `subprocess` need executable file path in unix format.