### PR TITLE
Update README.md with correct classpath

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,20 @@ buildscript {
         }
     }
     dependencies {
-        classpath 'gradle.plugin.org.mozilla.rust-android-gradle:plugin:0.8.6'
+        classpath 'org.mozilla.rust-android-gradle:plugin:0.8.6'
     }
+}
+```
+
+or 
+
+```groovy
+buildscript {
+    //...
+}
+
+plugins {
+    id "org.mozilla.rust-android-gradle.rust-android" version "0.8.6"
 }
 ```
 


### PR DESCRIPTION
The gradle classpath for the plugin returns a 403 and will fail to resolve on a new project. If you just drop the `gradle.plugin` part it works good though. This would be a quick fix to make starting out a little easier!

I've also added another way that developers can specify a plugin if they choose to.

Let me know if you think this would be useful!