### PR TITLE
Add per build type `cargoBuild${buildType}` tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,15 +53,17 @@ rustup target add x86_64-pc-windows-msvc    # for win32-x86-64-msvc
 ...
 ```
 
-Finally, run the `cargoBuild` task to cross compile:
+Finally, run a `cargoBuild${buildType}` task (see `buildTypeToProfile`) to cross compile:
 ```sh
-./gradlew cargoBuild
+./gradlew cargoBuildDebug
 ```
 Or add it as a dependency to one of your other build tasks, to build your rust code when you normally build your project:
 ```gradle
 tasks.whenTaskAdded { task ->
-    if ((task.name == 'javaPreCompileDebug' || task.name == 'javaPreCompileRelease')) {
-        task.dependsOn 'cargoBuild'
+    if (task.name == 'javaPreCompileDebug') {
+        task.dependsOn 'cargoBuildDebug'
+    } else if (task.name == 'javaPreCompileRelease') {
+        task.dependsOn 'cargoBuildRelease'
     }
 }
 ```
@@ -98,11 +100,6 @@ The [Android NDK](https://developer.android.com/ndk/guides/stable_apis) also fix
 which can be specified using the `apiLevel` option.  This option defaults to the minimum SDK API
 level.  As of API level 21, 64-bit builds are possible; and conversely, the `arm64` and `x86_64`
 targets require `apiLevel >= 21`.
-
-### Cargo release profile
-
-The `profile` option selects between the `--debug` and `--release` profiles in `cargo`.  *Defaults
-to `debug`!*
 
 ### Extension reference
 
@@ -190,17 +187,23 @@ cargo {
 }
 ```
 
-### profile
+### buildTypeToProfile
 
-The Cargo [release profile](https://doc.rust-lang.org/book/second-edition/ch14-01-release-profiles.html#customizing-builds-with-release-profiles) to build.
-
-Defaults to `"debug"`.
+This mandatory option specifies the Cargo [release profile](https://doc.rust-lang.org/book/second-edition/ch14-01-release-profiles.html#customizing-builds-with-release-profiles) to build per [Android build type](https://developer.android.com/studio/build/build-variants#build-types).
+Each entry in the map causes a new `cargoBuild${buildType}` task to be created.
 
 ```groovy
 cargo {
-    profile = 'release'
+    buildTypeToProfile = [
+        "debug": "debug",
+        "alpha": "debug",
+        "beta": "release",
+        "release": "release",
+    ]
 }
 ```
+
+The above example creates these targets: `cargoBuildDebug`, `cargoBuildAlpha`, `cargoBuildBeta`, `cargoBuildRelease`.
 
 ### features
 

--- a/plugin/src/main/kotlin/com/nishtahir/CargoExtension.kt
+++ b/plugin/src/main/kotlin/com/nishtahir/CargoExtension.kt
@@ -37,7 +37,7 @@ open class CargoExtension {
     var libname: String? = null
     var targets: List<String>? = null
     var prebuiltToolchains: Boolean? = null
-    var profile: String = "debug"
+    var buildTypeToProfile: Map<String, String> = mapOf()
     var verbose: Boolean? = null
     var targetDirectory: String? = null
     var targetIncludes: Array<String>? = null

--- a/samples/app/build.gradle
+++ b/samples/app/build.gradle
@@ -37,6 +37,10 @@ cargo {
     module = "../rust"
     targets = ["arm", "x86", "x86_64", "arm64"]
     libname = "rust"
+    buildTypeToProfile = [
+        "debug": "dev",
+        "release": "dev",
+    ]
 }
 
 repositories {
@@ -54,13 +58,13 @@ dependencies {
 }
 
 afterEvaluate {
-    // The `cargoBuild` task isn't available until after evaluation.
+    // The `cargoBuild...` tasks aren't available until after evaluation.
     android.applicationVariants.all { variant ->
         def productFlavor = ""
         variant.productFlavors.each {
             productFlavor += "${it.name.capitalize()}"
         }
         def buildType = "${variant.buildType.name.capitalize()}"
-        tasks["generate${productFlavor}${buildType}Assets"].dependsOn(tasks["cargoBuild"])
+        tasks["generate${productFlavor}${buildType}Assets"].dependsOn(tasks["cargoBuild${buildType}"])
     }
 }

--- a/samples/library/build.gradle
+++ b/samples/library/build.gradle
@@ -42,6 +42,10 @@ cargo {
         "darwin",
     ]
     libname = "rust"
+    buildTypeToProfile = [
+        "debug": "dev",
+        "release": "dev",
+    ]
 
     features {
         defaultAnd "foo", "bar"
@@ -68,13 +72,13 @@ dependencies {
 }
 
 afterEvaluate {
-    // The `cargoBuild` task isn't available until after evaluation.
+    // The `cargoBuild...` tasks aren't available until after evaluation.
     android.libraryVariants.all { variant ->
         def productFlavor = ""
         variant.productFlavors.each {
             productFlavor += "${it.name.capitalize()}"
         }
         def buildType = "${variant.buildType.name.capitalize()}"
-        tasks["generate${productFlavor}${buildType}Assets"].dependsOn(tasks["cargoBuild"])
+        tasks["generate${productFlavor}${buildType}Assets"].dependsOn(tasks["cargoBuild${buildType}"])
     }
 }


### PR DESCRIPTION
The goal of this change is to support explicitly building particular Cargo
profiles per Android build type. This change makes it possible to build
both release and debug tasks in a single gradle invocation without editing
the use of the `cargo` extension.

There are some backwards incompatible changes present:
`profile` is deprecated and is replaced with the *required* map `buildTypeToProfile`.
This map controls which `cargoBuild${buildType}` tasks are created and
what Cargo profile is used for each.  Once
https://github.com/rust-lang/cargo/issues/6988 is resolved and stabilized,
we should switch the implementation to use `cargo build --profile=$x`
explicitly rather than `--release`.