### PR TITLE
Generate toolchain even if destination directory exists

### DIFF
--- a/plugin/src/main/kotlin/com/nishtahir/GenerateToolchainsTask.kt
+++ b/plugin/src/main/kotlin/com/nishtahir/GenerateToolchainsTask.kt
@@ -40,13 +40,10 @@ open class GenerateToolchainsTask : DefaultTask() {
                         throw GradleException("Can't target 64-bit ${arch} with API level < 21 (${apiLevel})")
                     }
 
+                    // Always regenerate the toolchain, even if it exists
+                    // already. It is fast to do so and fixes any issues
+                    // with partially reclaimed temporary files.
                     val dir = File(cargoExtension.toolchainDirectory, arch + "-" + apiLevel)
-                    if (dir.exists()) {
-                        println("Toolchain for arch ${arch} version ${apiLevel} exists: checked ${dir}")
-                        return@forEach
-                    }
-
-                    println("Toolchain for arch ${arch} version ${apiLevel} does not exist: checked ${dir}")
                     project.exec { spec ->
                         spec.standardOutput = System.out
                         spec.errorOutput = System.out


### PR DESCRIPTION
Some developers (probably with low disk space) saw flaky builds because of toolchain directories that were partially reclaimed. Always regenerating the toolchain fixed things and didn't regress build speed much at all.