### PR TITLE
Replace '-lgcc' option in ndk 23. Fixes #75.

### DIFF
--- a/plugin/src/main/kotlin/com/nishtahir/CargoBuildTask.kt
+++ b/plugin/src/main/kotlin/com/nishtahir/CargoBuildTask.kt
@@ -167,6 +167,10 @@ open class CargoBuildTask : DefaultTask() {
                 if (toolchain.type != ToolchainType.DESKTOP) {
                     val toolchainDirectory = if (toolchain.type == ToolchainType.ANDROID_PREBUILT) {
                         val ndkPath = app.ndkDirectory
+                        val ndkVersion = ndkPath.name
+                        val ndkVersionMajor = ndkVersion.split(".").first()
+                        environment("CARGO_NDK_MAJOR_VERSION", ndkVersionMajor)
+
                         val hostTag = if (Os.isFamily(Os.FAMILY_WINDOWS)) {
                             if (Os.isArch("x86_64") || Os.isArch("amd64")) {
                                 "windows-x86_64"

--- a/plugin/src/main/resources/com/nishtahir/linker-wrapper.py
+++ b/plugin/src/main/resources/com/nishtahir/linker-wrapper.py
@@ -7,6 +7,13 @@ import sys
 
 args = [os.environ['RUST_ANDROID_GRADLE_CC'], os.environ['RUST_ANDROID_GRADLE_CC_LINK_ARG']] + sys.argv[1:]
 
+# The gcc library is not included starting from ndk version 23.
+ndk_major_version = os.environ['CARGO_NDK_MAJOR_VERSION']
+if ndk_major_version.isdigit():
+    if 23 <= int(ndk_major_version):
+        args.remove("-lgcc")
+        args.append("-lunwind")
+
 # This only appears when the subprocess call fails, but it's helpful then.
 printable_cmd = ' '.join(pipes.quote(arg) for arg in args)
 print(printable_cmd)


### PR DESCRIPTION
Hi. I am a user of this plugin and I am always grateful using it. 👍👍 

When I ran the new rust library file with NDK 23, the same issue as #75 occurred. 
There were no issues with rust projects that were already built with an older ndk version.
(Just change the name of the rust library you want to build, and you'll see the issue.)

In ndk 23, I confirmed that the gcc library doesn't exist.

After changing the code, the build proceeded normally.
I would really appreciate it if you could check this issue please.

Once again, Thank you :)

[reference](https://github.com/rust-windowing/android-ndk-rs/pull/189)
