### PR TITLE
Fix sample app for Android >= 12

### DIFF
--- a/samples/app/src/main/AndroidManifest.xml
+++ b/samples/app/src/main/AndroidManifest.xml
@@ -11,7 +11,8 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
-        <activity android:name=".MainActivity">
+        <activity android:name=".MainActivity"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 


### PR DESCRIPTION
When installing the sample app on a recent Android, I get this error:

> As of Android 12, `android:exported` must be set; use `true` to make the activity
> available to other apps, and `false` otherwise. For launcher activities, this should be set to `true`.

This PR fix this ;-)