### PR TITLE
With NDK 23+, look for `llvm-ar`, not target triple-specific `...-ar`. Fixes #91.

### DIFF
--- a/plugin/src/main/kotlin/com/nishtahir/CargoBuildTask.kt
+++ b/plugin/src/main/kotlin/com/nishtahir/CargoBuildTask.kt
@@ -165,10 +165,15 @@ open class CargoBuildTask : DefaultTask() {
 
                 // Cross-compiling to Android requires toolchain massaging.
                 if (toolchain.type != ToolchainType.DESKTOP) {
+                    val ndkPath = app.ndkDirectory
+                    val ndkVersion = ndkPath.name
+                    val ndkVersionMajor = try {
+                        ndkVersion.split(".").first().toInt()
+                    } catch (ex: NumberFormatException) {
+                        0 // Falls back to generic behaviour.
+                    }
+
                     val toolchainDirectory = if (toolchain.type == ToolchainType.ANDROID_PREBUILT) {
-                        val ndkPath = app.ndkDirectory
-                        val ndkVersion = ndkPath.name
-                        val ndkVersionMajor = ndkVersion.split(".").first()
                         environment("CARGO_NDK_MAJOR_VERSION", ndkVersionMajor)
 
                         val hostTag = if (Os.isFamily(Os.FAMILY_WINDOWS)) {
@@ -197,7 +202,7 @@ open class CargoBuildTask : DefaultTask() {
 
                     val cc = File(toolchainDirectory, "${toolchain.cc(apiLevel)}").path;
                     val cxx = File(toolchainDirectory, "${toolchain.cxx(apiLevel)}").path;
-                    val ar = File(toolchainDirectory, "${toolchain.ar(apiLevel)}").path;
+                    val ar = File(toolchainDirectory, "${toolchain.ar(apiLevel, ndkVersionMajor)}").path;
 
                     // For build.rs in `cc` consumers: like "CC_i686-linux-android".  See
                     // https://github.com/alexcrichton/cc-rs#external-configuration-via-environment-variables.

--- a/plugin/src/main/kotlin/com/nishtahir/RustAndroidPlugin.kt
+++ b/plugin/src/main/kotlin/com/nishtahir/RustAndroidPlugin.kt
@@ -143,8 +143,10 @@ data class Toolchain(val platform: String,
                 }
             }
 
-    fun ar(apiLevel: Int): File =
-            if (type == ToolchainType.ANDROID_PREBUILT) {
+    fun ar(apiLevel: Int, ndkVersionMajor: Int): File =
+            if (ndkVersionMajor >= 23) {
+                File("bin", "llvm-ar")
+            } else if (type == ToolchainType.ANDROID_PREBUILT) {
                 File("bin", "$binutilsTriple-ar")
             } else {
                 File("$platform-$apiLevel/bin", "$binutilsTriple-ar")


### PR DESCRIPTION
I'd prefer to do this by interrogating the binaries on disk, using
something like `which`, but the current expression makes that a little
hard to achieve, so we'll feed the NDK version into the relevant
helper function for now.