### PR TITLE
Replace `-lgcc` with `-lunwind` in linker argument @files. Fixes #89.

### DIFF
--- a/plugin/src/main/resources/com/nishtahir/linker-wrapper.py
+++ b/plugin/src/main/resources/com/nishtahir/linker-wrapper.py
@@ -5,19 +5,35 @@ import pipes
 import subprocess
 import sys
 
-args = [os.environ['RUST_ANDROID_GRADLE_CC'], os.environ['RUST_ANDROID_GRADLE_CC_LINK_ARG']] + sys.argv[1:]
+args = [
+    os.environ["RUST_ANDROID_GRADLE_CC"],
+    os.environ["RUST_ANDROID_GRADLE_CC_LINK_ARG"],
+] + sys.argv[1:]
 
-# The `gcc` library is not included starting from NDK version 23.
-# Work around by using `unwind` replacement.
-ndk_major_version = os.environ['CARGO_NDK_MAJOR_VERSION']
-if ndk_major_version.isdigit():
-    if 23 <= int(ndk_major_version):
-        for i, arg in enumerate(args):
-            if arg == "-lgcc":
-                args[i] = "-lunwind"
+
+def update_in_place(arglist):
+    # The `gcc` library is not included starting from NDK version 23.
+    # Work around by using `unwind` replacement.
+    ndk_major_version = os.environ["CARGO_NDK_MAJOR_VERSION"]
+    if ndk_major_version.isdigit():
+        if 23 <= int(ndk_major_version):
+            for i, arg in enumerate(arglist):
+                if arg.startswith("-lgcc"):
+                    # This is one way to preserve line endings.
+                    arglist[i] = "-lunwind" + arg[len("-lgcc") :]
+
+
+update_in_place(args)
+
+for arg in args:
+    if arg.startswith("@"):
+        fileargs = open(arg[1:], "r").read().splitlines(keepends=True)
+        update_in_place(fileargs)
+        open(arg[1:], "w").write("".join(fileargs))
+
 
 # This only appears when the subprocess call fails, but it's helpful then.
-printable_cmd = ' '.join(pipes.quote(arg) for arg in args)
+printable_cmd = " ".join(pipes.quote(arg) for arg in args)
 print(printable_cmd)
 
 sys.exit(subprocess.call(args))


### PR DESCRIPTION
This applies the fix of #83 to linker argument @files.  Linker
argument files are used on (at least) Windows.