### PR TITLE
Capture inputs and outputs for generated tasks

### DIFF
--- a/plugin/src/main/kotlin/com/nishtahir/CargoBuildTask.kt
+++ b/plugin/src/main/kotlin/com/nishtahir/CargoBuildTask.kt
@@ -6,13 +6,13 @@ import org.gradle.api.DefaultTask
 import org.gradle.api.GradleException
 import org.gradle.api.Project
 import org.gradle.api.logging.LogLevel
-import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.TaskAction
 import java.io.ByteArrayOutputStream
 import java.io.File
 
 open class CargoBuildTask : DefaultTask() {
-    @Input
+    @Internal
     var toolchain: Toolchain? = null
 
     @Suppress("unused")

--- a/plugin/src/main/kotlin/com/nishtahir/RustAndroidPlugin.kt
+++ b/plugin/src/main/kotlin/com/nishtahir/RustAndroidPlugin.kt
@@ -312,7 +312,7 @@ open class RustAndroidPlugin : Plugin<Project> {
                 toolchain = theToolchain
                 inputs.dir("${cargoExtension.module}/src")
                 inputs.file("${cargoExtension.module}/Cargo.toml")
-                outputs.dir(outDir)
+                outputs.dirs(outDir, File(buildDir, "rustJniLibs/${theToolchain.folder}"))
             }
 
             if (!usePrebuilt) {


### PR DESCRIPTION
This pull request will close #41 as it introduces Gradle's file watching behavior. The only possible problem may be a Cargo.toml [custom source path](https://users.rust-lang.org/t/cargo-how-to-use-a-different-directory-to-store-source-files/22802/3) case, which I believe can be solved by extending class `CargoExtension` with custom source path. If you think that this case should be handled, let me know/feel free to edit