### PR TITLE
Update versions of Gradle to 7.6 and Kotlin to 1.8.10

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ buildscript {
     Properties versionProperties = new Properties()
     versionProperties.load(new FileInputStream("$project.rootDir/version.properties"))
 
-    ext.kotlin_version = '1.3.50'
+    ext.kotlin_version = '1.8.10'
     ext.agp_version = '4.0.1'
     ext.plugin_version = versionProperties.getProperty("version")
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.1.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -61,6 +61,11 @@ dependencies {
     testImplementation "org.junit.jupiter:junit-jupiter-api"
 }
 
+java {
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(8))
+    }
+}
 compileKotlin {
     kotlinOptions.jvmTarget = "1.8"
 }

--- a/plugin/src/main/kotlin/com/nishtahir/CargoBuildTask.kt
+++ b/plugin/src/main/kotlin/com/nishtahir/CargoBuildTask.kt
@@ -133,6 +133,9 @@ open class CargoBuildTask : DefaultTask() {
                             theCommandLine.add(features.featureSet.joinToString(" "))
                         }
                     }
+                    else -> {
+                        // when() must be exhaustive
+                    }
                 }
 
                 if (cargoExtension.profile != "debug") {


### PR DESCRIPTION
I have Java 17 installed on my system and I couldn't actually launch the project, due to Unsupported class major version 61 errors.

(See: https://stackoverflow.com/questions/69425829/unsupported-class-file-major-version-61-error)

Updating Gradle to 7.6 fixed it, though I didn't want to go as far as jumping to Gradle 8. I also needed to update the Kotlin version, I was getting some annoying collisions in my Gradle cache.

This is in prep for a second PR adding test support for AGP 7.4.2.