### PR TITLE
Use `python3` instead of `python`

### DIFF
--- a/plugin/src/main/kotlin/com/nishtahir/CargoExtension.kt
+++ b/plugin/src/main/kotlin/com/nishtahir/CargoExtension.kt
@@ -97,7 +97,7 @@ open class CargoExtension {
             return if (!field.isEmpty()) {
                 field
             } else {
-                getProperty("rust.pythonCommand", "RUST_ANDROID_GRADLE_PYTHON_COMMAND") ?: "python"
+                getProperty("rust.pythonCommand", "RUST_ANDROID_GRADLE_PYTHON_COMMAND") ?: "python3"
             }
         }
 


### PR DESCRIPTION
`python` hasn't existed on macOS since 12.3. And `python3` _should_ exist on any modern Linux installation.