### PR TITLE
Fix CI tests

### DIFF
--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     # Everything here was cribbed from or inspired by
     # https://github.com/oflynned/android-version-bump/blob/b9f6de7f8bdf25de3f695843265debf7c3919272.

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -15,14 +15,14 @@ jobs:
 
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE for the job.
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Gradle test
         run: |
           ./gradlew -p plugin generateTestTasksJson
 
       - id: setup-matrix
-        run: echo "::set-output name=matrix::$(cat plugin/build/build-resources/androidTestTasks.json)"
+        run: echo "matrix=$(cat plugin/build/build-resources/androidTestTasks.json)" >> $GITHUB_OUTPUT
 
       - name: debug
         run: echo ${{ steps.setup-matrix.outputs.matrix }}
@@ -44,17 +44,31 @@ jobs:
 
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE for the job.
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
-      - name: Setup Rust
+      - name: Setup Rust stable
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: x86_64-linux-android,x86_64-unknown-linux-gnu,aarch64-linux-android
+
+      - name: Setup Rust 1.67
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: 1.67
+          targets: x86_64-linux-android,x86_64-unknown-linux-gnu,aarch64-linux-android
+
+      - name: Setup NDK
+        env:
+          SDKMANAGER: /cmdline-tools/latest/bin/sdkmanager
         run: |
-          rustup toolchain install stable
-          rustup target add x86_64-linux-android
-          rustup target add x86_64-unknown-linux-gnu
-          rustup target add aarch64-linux-android
+          if [[ "${{ runner.os }}" == "Windows" ]]; then
+            SDKMANAGER=$(echo $SDKMANAGER | tr '/' '\').bat
+          fi
+          ${ANDROID_HOME}${SDKMANAGER} --install 'ndk;21.4.7075529' 'ndk;23.1.7779620'
+        shell: bash
 
       - name: Setup Java 11
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: 11
@@ -87,18 +101,32 @@ jobs:
 
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE for the job.
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
-      - name: Setup Rust
+      - name: Setup Rust stable
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: x86_64-linux-android,x86_64-unknown-linux-gnu,aarch64-linux-android
+
+      - name: Setup Rust 1.67
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: 1.67
+          targets: x86_64-linux-android,x86_64-unknown-linux-gnu,aarch64-linux-android
+
+      - name: Setup NDK
+        env:
+          SDKMANAGER: /cmdline-tools/latest/bin/sdkmanager
         run: |
-          rustup toolchain install stable
-          rustup target add x86_64-linux-android
-          rustup target add x86_64-unknown-linux-gnu
-          rustup target add aarch64-linux-android
+          if [[ "${{ runner.os }}" == "Windows" ]]; then
+            SDKMANAGER=$(echo $SDKMANAGER | tr '/' '\').bat
+          fi
+          ${ANDROID_HOME}${SDKMANAGER} --install 'ndk;21.4.7075529' 'ndk;23.1.7779620'
+        shell: bash
 
       # Use Java 8
       - name: Setup Java 8
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: 8
@@ -135,18 +163,32 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
-      - name: Setup Rust
+      - name: Setup NDK
+        env:
+          SDKMANAGER: /cmdline-tools/latest/bin/sdkmanager
         run: |
-          rustup toolchain install stable
-          rustup target add x86_64-linux-android
-          rustup target add x86_64-unknown-linux-gnu
-          rustup target add aarch64-linux-android
+          if [[ "${{ runner.os }}" == "Windows" ]]; then
+            SDKMANAGER=$(echo $SDKMANAGER | tr '/' '\').bat
+          fi
+          ${ANDROID_HOME}${SDKMANAGER} --install 'ndk;21.4.7075529' 'ndk;23.1.7779620'
+        shell: bash
+
+      - name: Setup Rust stable
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: x86_64-linux-android,x86_64-unknown-linux-gnu,aarch64-linux-android
+
+      - name: Setup Rust 1.67
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: 1.67
+          targets: x86_64-linux-android,x86_64-unknown-linux-gnu,aarch64-linux-android
 
       # Use Java 8
       - name: Setup Java 8
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: 8

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,10 +9,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - name: Set up JDK 8
-      uses: actions/setup-java@v2
+      uses: actions/setup-java@v4
       with:
         java-version: '8'
         distribution: 'temurin'

--- a/plugin/src/test/groovy/com/nishtahir/CargoTargetTest.groovy
+++ b/plugin/src/test/groovy/com/nishtahir/CargoTargetTest.groovy
@@ -11,9 +11,15 @@ class CargoTargetTest extends AbstractTest {
     def "cargoBuild produces #location for target #target"() {
         given:
         def androidVersion = TestVersions.latestAndroidVersionForCurrentJDK()
+        def ndkVersion = "21.4.7075529"
+        def ndkVersionMajor = ndkVersion.split('\\.')[0] as int
+        // Toolchain 1.68 or later versions are not compatible to old NDK prior to r23
+        // https://blog.rust-lang.org/2023/01/09/android-ndk-update-r25.html
+        def channel = ndkVersionMajor >= 23 ? "stable" : "1.67"
 
         SimpleAndroidApp.builder(temporaryFolder.root, cacheDir)
                 .withAndroidVersion(androidVersion)
+                .withNdkVersion(ndkVersion)
                 .withKotlinDisabled()
         // TODO: .withCargo(...)
                 .build()
@@ -21,6 +27,7 @@ class CargoTargetTest extends AbstractTest {
 
         SimpleCargoProject.builder(temporaryFolder.root)
                 .withTargets([target])
+                .withChannel(channel)
                 .build()
                 .writeProject()
 

--- a/plugin/src/test/groovy/com/nishtahir/NdkVersionTest.groovy
+++ b/plugin/src/test/groovy/com/nishtahir/NdkVersionTest.groovy
@@ -13,6 +13,10 @@ class NdkVersionTest extends AbstractTest {
         def androidVersion = TestVersions.latestAndroidVersionForCurrentJDK()
         def target = "x86_64"
         def location = "android/x86_64/librust.so"
+        def ndkVersionMajor = ndkVersion.split('\\.')[0] as int
+        // Toolchain 1.68 or later versions are not compatible to old NDK prior to r23
+        // https://blog.rust-lang.org/2023/01/09/android-ndk-update-r25.html
+        def channel = ndkVersionMajor >= 23 ? "stable" : "1.67"
 
         SimpleAndroidApp.builder(temporaryFolder.root, cacheDir)
                 .withAndroidVersion(androidVersion)
@@ -24,6 +28,7 @@ class NdkVersionTest extends AbstractTest {
 
         SimpleCargoProject.builder(temporaryFolder.root)
                 .withTargets([target])
+                .withChannel(channel)
                 .build()
                 .writeProject()
 
@@ -55,11 +60,14 @@ class NdkVersionTest extends AbstractTest {
 
         where:
         ndkVersion << [
-            // NDK versions supported by Github Actions, per
-            // https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu2004-Readme.md.
+            // Old LTS NDKs need to be installed manually
             "21.4.7075529",
-            "22.1.7171670",
             "23.1.7779620",
+            // NDK versions supported by Github Actions, per
+            // https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2004-Readme.md#android
+            "24.0.8215888",
+            "25.2.9519653",
+            "26.1.10909125",
         ]
     }
 }

--- a/plugin/src/test/groovy/com/nishtahir/SimpleAndroidApp.groovy
+++ b/plugin/src/test/groovy/com/nishtahir/SimpleAndroidApp.groovy
@@ -156,8 +156,7 @@ class SimpleAndroidApp {
     }
 
     private String getMaybeNdkVersion() {
-        def isAndroid34x = androidVersion >= android("3.4.0")
-        if (isAndroid34x) {
+        if (ndkVersion != null) {
             return """ndkVersion '${ndkVersion}'"""
         } else {
             return ""
@@ -275,7 +274,7 @@ class SimpleAndroidApp {
         boolean kaptWorkersEnabled = true
 
         VersionNumber androidVersion = Versions.latestAndroidVersion()
-        VersionNumber ndkVersion = Versions.latestAndroidVersion() >= android("3.4.0") ? VersionNumber.parse("21.4.7075529") : null
+        VersionNumber ndkVersion = null
 
         VersionNumber kotlinVersion = VersionNumber.parse("1.3.72")
         File projectDir
@@ -303,9 +302,6 @@ class SimpleAndroidApp {
 
         Builder withAndroidVersion(VersionNumber androidVersion) {
             this.androidVersion = androidVersion
-            if (this.androidVersion < android("3.4.0")) {
-                this.ndkVersion = null
-            }
             return this
         }
 
@@ -333,6 +329,9 @@ class SimpleAndroidApp {
         }
 
         SimpleAndroidApp build() {
+            if (ndkVersion == null && androidVersion >= android("3.4.0")) {
+                ndkVersion = VersionNumber.parse("21.4.7075529")
+            }
             return new SimpleAndroidApp(projectDir, cacheDir, androidVersion, ndkVersion, kotlinVersion, kotlinEnabled, kaptWorkersEnabled)
         }
     }

--- a/plugin/src/test/groovy/com/nishtahir/SimpleCargoProject.groovy
+++ b/plugin/src/test/groovy/com/nishtahir/SimpleCargoProject.groovy
@@ -3,15 +3,18 @@ package com.nishtahir
 class SimpleCargoProject {
     File projectDir
     List<String> targets
+    String channel
 
-    SimpleCargoProject(File projectDir, List<String> targets) {
+    SimpleCargoProject(File projectDir, List<String> targets, String channel) {
         this.projectDir = projectDir
         this.targets = targets
+        this.channel = channel
     }
 
     static class Builder {
         File projectDir
         List<String> targets
+        String channel
 
         Builder(File projectDir) {
             this.projectDir = projectDir
@@ -22,11 +25,16 @@ class SimpleCargoProject {
             return this
         }
 
+        def withChannel(channel) {
+            this.channel = channel
+            return this
+        }
+
         def build() {
             if (targets.isEmpty()) {
                 throw new IllegalStateException("No targets provided")
             }
-            return new SimpleCargoProject(this.projectDir, this.targets)
+            return new SimpleCargoProject(this.projectDir, this.targets, this.channel)
         }
     }
 
@@ -70,5 +78,11 @@ class SimpleCargoProject {
                     libname = "rust"
                 }
             """.stripIndent()
+
+        if (channel != null) {
+            file('local.properties') << """
+                rust.rustupChannel=${channel}
+            """.stripIndent()
+        }
     }
 }


### PR DESCRIPTION
Hi,
I use this rust-android-gradle plugin in every project with Android and Rust. So I hope I can contribute to this plugin.

I noticed that the CI tests failed in my fork. There are two reasons for this:
- GitHub Actions' runner image update (NDKs)
- Rust compatibility to NDK has changed ([announcement](https://blog.rust-lang.org/2023/01/09/android-ndk-update-r25.html))

I fixed these problems by
- updating NDK versions used in the test and adding manual installation steps for old NDKs in the CI workflow
- adding rust channel (toolchain) configuration in tests depending on NDK versions

Also, I update several actions to erase workflow warnings.

