### PR TITLE
ci: Use GITHUB_OUTPUT envvar instead of set-output command

### DIFF
--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -58,7 +58,7 @@ jobs:
         git push "${remote}" --follow-tags
         git push "${remote}" --tags
 
-        echo "::set-output name=new_tag::v${{ github.event.inputs.new_version }}"
+        echo "new_tag=v${{ github.event.inputs.new_version }}" >> $GITHUB_OUTPUT
 
     - name: Create release
       id: create_release

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -22,7 +22,7 @@ jobs:
           ./gradlew -p plugin generateTestTasksJson
 
       - id: setup-matrix
-        run: echo "::set-output name=matrix::$(cat plugin/build/build-resources/androidTestTasks.json)"
+        run: echo "matrix=$(cat plugin/build/build-resources/androidTestTasks.json)" >> $GITHUB_OUTPUT
 
       - name: debug
         run: echo ${{ steps.setup-matrix.outputs.matrix }}


### PR DESCRIPTION
`save-state` and `set-output` commands used in GitHub Actions are deprecated and [GitHub recommends using environment files](https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/).

This PR updates the usage of `set-output` to `$GITHUB_OUTPUT`

Instructions for envvar usage from GitHub docs:

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter


