### PR TITLE
Replace pipes with shlex in the linker-wrapper

### DIFF
--- a/plugin/src/main/resources/com/nishtahir/linker-wrapper.py
+++ b/plugin/src/main/resources/com/nishtahir/linker-wrapper.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import, print_function, unicode_literals
 
 import os
-import pipes
+import shlex
 import subprocess
 import sys
 
@@ -33,7 +33,7 @@ for arg in args:
 
 
 # This only appears when the subprocess call fails, but it's helpful then.
-printable_cmd = " ".join(pipes.quote(arg) for arg in args)
+printable_cmd = " ".join(shlex.quote(arg) for arg in args)
 print(printable_cmd)
 
 sys.exit(subprocess.call(args))


### PR DESCRIPTION
`pipes` is gone in Python 3.13.
`pipes.quote` was _already_ just an alias for `shlex.quote` in Python 3.12 ([source](https://github.com/python/cpython/blob/3.12/Lib/pipes.py#L64-L66)).