### PR TITLE
Add --build-id to the linker flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,6 +341,10 @@ cargo {
 }
 ```
 
+### generateBuildId
+
+Generate a build-id for the shared library during the link phase.
+
 ### exec
 
 This is a callback taking the `ExecSpec` we're going to use to invoke `cargo build`, and

--- a/plugin/src/main/kotlin/com/nishtahir/CargoBuildTask.kt
+++ b/plugin/src/main/kotlin/com/nishtahir/CargoBuildTask.kt
@@ -228,7 +228,11 @@ open class CargoBuildTask : DefaultTask() {
                     environment("RUST_ANDROID_GRADLE_LINKER_WRAPPER_PY",
                             File(project.rootProject.buildDir, "linker-wrapper/linker-wrapper.py").path)
                     environment("RUST_ANDROID_GRADLE_CC", cc)
-                    environment("RUST_ANDROID_GRADLE_CC_LINK_ARG", "-Wl,-soname,lib${cargoExtension.libname!!}.so")
+                    if (cargoExtension.generateBuildId) {
+                        environment("RUST_ANDROID_GRADLE_CC_LINK_ARG", "-Wl,--build-id,-soname,lib${cargoExtension.libname!!}.so")
+                    } else {
+                        environment("RUST_ANDROID_GRADLE_CC_LINK_ARG", "-Wl,-soname,lib${cargoExtension.libname!!}.so")
+                    }
                 }
 
                 cargoExtension.extraCargoBuildArguments?.let {

--- a/plugin/src/main/kotlin/com/nishtahir/CargoExtension.kt
+++ b/plugin/src/main/kotlin/com/nishtahir/CargoExtension.kt
@@ -44,6 +44,7 @@ open class CargoExtension {
     var apiLevel: Int? = null
     var apiLevels: Map<String, Int> = mapOf()
     var extraCargoBuildArguments: List<String>? = null
+    var generateBuildId: Boolean = false
 
     // It would be nice to use a receiver here, but there are problems interoperating with Groovy
     // and Kotlin that are just not worth working out.  Another JVM language, yet another dynamic


### PR DESCRIPTION
See https://bugzilla.mozilla.org/show_bug.cgi?id=1937916 for the reasoning here.  I tested this with a Maven local publish and it worked for me.

This could also be behind an option, either one specifically for `build-id` or a general one like `EXTRA_LINKER_ARGS`.  It seems like `build-id` is a good default though so I didn't implement it that way on the first pass.